### PR TITLE
[#88] fix default `ContextOperator`: change `B` to comparable

### DIFF
--- a/operator.go
+++ b/operator.go
@@ -5,24 +5,26 @@ import (
 )
 
 // ContextOperator inject and extract Tx from context.Context.
-type ContextOperator[B any, T Tx] struct {
-	beginner *B
+//
+// Default ContextOperator uses comparable key for context.Context value operation.
+type ContextOperator[K comparable, T Tx] struct {
+	key K
 }
 
 // NewContextOperator returns new ContextOperator.
-func NewContextOperator[B any, T Tx](b *B) *ContextOperator[B, T] {
-	return &ContextOperator[B, T]{
-		beginner: b,
+func NewContextOperator[K comparable, T Tx](key K) *ContextOperator[K, T] {
+	return &ContextOperator[K, T]{
+		key: key,
 	}
 }
 
 // Inject returns new context.Context contains Tx as value.
-func (p *ContextOperator[B, T]) Inject(ctx context.Context, tx T) context.Context {
-	return context.WithValue(ctx, p.beginner, tx)
+func (p *ContextOperator[K, T]) Inject(ctx context.Context, tx T) context.Context {
+	return context.WithValue(ctx, p.key, tx)
 }
 
 // Extract returns Tx extracted from context.Context.
-func (p *ContextOperator[B, T]) Extract(ctx context.Context) (T, bool) {
-	c, ok := ctx.Value(p.beginner).(T)
+func (p *ContextOperator[K, T]) Extract(ctx context.Context) (T, bool) {
+	c, ok := ctx.Value(p.key).(T)
 	return c, ok
 }

--- a/stdlib/transactor.go
+++ b/stdlib/transactor.go
@@ -25,7 +25,7 @@ type dbWrapper struct {
 }
 
 // BeginTx starts a transaction.
-func (db *dbWrapper) BeginTx(ctx context.Context, opts ...oniontx.Option[*sql.TxOptions]) (*txWrapper, error) {
+func (db dbWrapper) BeginTx(ctx context.Context, opts ...oniontx.Option[*sql.TxOptions]) (*txWrapper, error) {
 	var txOptions sql.TxOptions
 	for _, opt := range opts {
 		opt.Apply(&txOptions)
@@ -58,12 +58,12 @@ type Transactor struct {
 // NewTransactor returns new Transactor.
 func NewTransactor(db *sql.DB) *Transactor {
 	var (
-		base       = &dbWrapper{DB: db}
+		base       = dbWrapper{DB: db}
 		operator   = oniontx.NewContextOperator[*dbWrapper, *txWrapper](&base)
 		transactor = Transactor{
 			operator: operator,
 			transactor: oniontx.NewTransactor[*dbWrapper, *txWrapper, *sql.TxOptions](
-				base,
+				&base,
 				operator,
 			),
 		}


### PR DESCRIPTION
### Description
1️⃣ Fix `ContextOperator`. Change the `B` type (`any` -> `comparable`)
2️⃣ Change `ContextOperator` constructor: remove pointer of the `B` type.
3️⃣ Rename `ContextOperator`  field: `beginner` -> key
```Golang
// ContextOperator inject and extract Tx from context.Context.
//
// Default ContextOperator uses comparable key for context.Context value operation.
type ContextOperator[B comparable, T Tx] struct {
	key B
}
```

Closes #88