### PR TITLE
[#107] run `release` github's action only by tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 on:
-  push:
+  create:
     tags:
       - "v*.*.*"
 


### PR DESCRIPTION
### Description
`oniontx/.github/workflows/release.yml` action was fixed.

Closes #107