### PR TITLE
Feature/212 track and tracker

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -463,11 +463,13 @@ steps := []saga.Step{
         WithCompensation(
             saga.NewCompensation(func(ctx context.Context, track saga.Track) error {
                 // Compensation logic.
-                // Use track.GetData() to inspect what failed
-                data := track.GetData()
+                // Get data to understand what failed
+                data := track.GetStepData()
+
+                // Log the error that triggered compensation
                 if len(data.Action.Errors) > 0 {
-                    log.Printf("Compensating for error: %v", data.Action.Errors[0])
-                }
+                    fmt.Printf("Compensating for error: %v\n", data.Action.Errors[0])
+				}
                 return performCompensation(ctx)
             }).
                 // Compensation can also have retry logic

--- a/examples/sage_test.go
+++ b/examples/sage_test.go
@@ -69,7 +69,7 @@ func Test_Saga_example(t *testing.T) {
 				//   - track.GetData().Action.Status — status of the action
 				Compensation: func(ctx context.Context, track saga.Track) error {
 					// Get execution data to make decisions based on error type
-					data := track.GetData()
+					data := track.GetStepData()
 
 					// Example: conditional compensation based on error
 					if len(data.Action.Errors) > 0 {
@@ -140,8 +140,8 @@ func Test_Saga_example(t *testing.T) {
 						data := track.GetData()
 
 						// Log the error that triggered compensation
-						if len(data.Action.Errors) > 0 {
-							fmt.Printf("Compensating for error: %v\n", data.Action.Errors[0])
+						if len(data.Action.errors) > 0 {
+							fmt.Printf("Compensating for error: %v\n", data.Action.errors[0])
 						}
 
 						// Perform compensation

--- a/examples/sage_test.go
+++ b/examples/sage_test.go
@@ -119,7 +119,9 @@ func Test_Saga_example(t *testing.T) {
 						// Simulate error to demonstrate retry
 						// Record the error in track
 						err := fmt.Errorf("first_step_Error")
-						track.SetFailedOnError(err)
+						track.SetStatus(saga.ExecutionStatusFail)
+						// add the error to the errors list
+						track.AddError(err)
 						return err
 					}).
 						// Protection against panics — important for production!
@@ -137,11 +139,11 @@ func Test_Saga_example(t *testing.T) {
 					saga.NewCompensation(func(ctx context.Context, track saga.Track) error {
 						// Compensation logic.
 						// Get data to understand what failed
-						data := track.GetData()
+						data := track.GetStepData()
 
 						// Log the error that triggered compensation
-						if len(data.Action.errors) > 0 {
-							fmt.Printf("Compensating for error: %v\n", data.Action.errors[0])
+						if len(data.Action.Errors) > 0 {
+							fmt.Printf("Compensating for error: %v\n", data.Action.Errors[0])
 						}
 
 						// Perform compensation

--- a/saga/actions.go
+++ b/saga/actions.go
@@ -84,7 +84,8 @@ func (a ActionFunc) WithAfterHook(after func(ctx context.Context, track Track) e
 	return func(ctx context.Context, track Track) error {
 		err := a(ctx, track)
 		if err != nil {
-			track.SetFailedOnError(err)
+			track.SetStatus(ExecutionStatusFail)
+			track.AddError(err)
 		}
 		err = after(ctx, track)
 		if err != nil {
@@ -225,7 +226,8 @@ func (c CompensationFunc) WithAfterHook(after func(ctx context.Context, track Tr
 	return func(ctx context.Context, track Track) error {
 		err := c(ctx, track)
 		if err != nil {
-			track.SetFailedOnError(err)
+			track.SetStatus(ExecutionStatusFail)
+			track.AddError(err)
 		}
 		err = after(ctx, track)
 		if err != nil {

--- a/saga/result.go
+++ b/saga/result.go
@@ -57,7 +57,7 @@ func (r Result) String() string {
 // Returns:
 //   - Result: aggregated execution data for all steps
 //   - error: descriptive error with categorized lists of failed/compensated steps
-func prepareResult(tracks []*inMemoryTracker) (Result, error) {
+func prepareResult(tracks []*simpleTracker) (Result, error) {
 	var (
 		result = Result{
 			Steps:  make([]StepData, 0, len(tracks)),

--- a/saga/result.go
+++ b/saga/result.go
@@ -57,7 +57,7 @@ func (r Result) String() string {
 // Returns:
 //   - Result: aggregated execution data for all steps
 //   - error: descriptive error with categorized lists of failed/compensated steps
-func prepareResult(tracks []*inMemoryTrack) (Result, error) {
+func prepareResult(tracks []*inMemoryTracker) (Result, error) {
 	var (
 		result = Result{
 			Steps:  make([]StepData, 0, len(tracks)),
@@ -88,7 +88,7 @@ func prepareResult(tracks []*inMemoryTrack) (Result, error) {
 	)
 
 	for _, tr := range tracks {
-		data := tr.GetData()
+		data := tr.GetStepData()
 		result.Steps = append(result.Steps, data)
 
 		stepID := prepareStateStrFn(data.StepPosition, data.StepName)

--- a/saga/retry.go
+++ b/saga/retry.go
@@ -152,18 +152,19 @@ func WithRetry(opt RetryPolicy, fn func(ctx context.Context, track Track) error)
 		case attempts == 0:
 			return err
 		case err != nil:
-			track.SetFailedOnError(err)
-
+			track.SetStatus(ExecutionStatusFail)
+			track.AddError(err)
 		}
 
 		// retries
 	stop:
 		for i := uint32(0); i < attempts; i++ {
-			track.call()
-			track.setParentError(fmt.Errorf("retry [%d]", i))
+			track.Call()
+			track.SetParentError(fmt.Errorf("retry [%d]", i))
 			select {
 			case <-ctx.Done():
-				track.SetFailedOnError(
+				track.SetStatus(ExecutionStatusFail)
+				track.AddError(
 					errors.Join(ErrRetryContextDone, ctx.Err()),
 				)
 				break stop
@@ -173,14 +174,15 @@ func WithRetry(opt RetryPolicy, fn func(ctx context.Context, track Track) error)
 					track.SetStatus(ExecutionStatusSuccess)
 					break stop
 				}
-				track.SetFailedOnError(err)
+				track.SetStatus(ExecutionStatusFail)
+				track.AddError(err)
 				if i < attempts-1 {
 					time.Sleep(opt.Delay(i))
 				}
 			}
 		}
 
-		track.setParentError(nil)
+		track.SetParentError(nil)
 		return nil
 	}
 }

--- a/saga/retry.go
+++ b/saga/retry.go
@@ -128,15 +128,19 @@ func (o AdvanceRetryPolicy) Delay(i uint32) time.Duration {
 // The function respects context cancellation and will return context.Err() if done.
 //
 // Behavior:
-//   - If Attempts() = 0, the function immediately returns nil without executing fn
-//   - Before each attempt, it waits for the delay provided by opt.Delay(attempt)
-//   - The function stops retrying on first successful execution
-//   - Context cancellation is respected between attempts (checked before each attempt)
-//   - All Errors from failed attempts are collected
+//   - If attempts = 0, the function executes fn once and returns its result
+//   - On first successful execution, returns nil and sets status to ExecutionStatusSuccess
+//   - On failure, retries up to attempts times with delays between attempts
+//   - Context cancellation is respected before each attempt
+//   - All errors from failed attempts are collected in Track.Errors
+//   - Each retry attempt is wrapped with a "retry [N]" prefix for error context
 //
-// If all attempts fail, behavior depends on ReturnAllAroseErr():
-//   - if true - returns all Errors via Errors.Join(...)
-//   - if false - returns only the last error that occurred
+// Return values:
+//   - nil if any attempt succeeds
+//   - ErrRetryContextDone if context is cancelled during retry waiting
+//   - ErrRetryFailed if all attempts fail (including the initial call)
+//
+// The original error from the final attempt is NOT returned directly;
 func WithRetry(opt RetryPolicy, fn func(ctx context.Context, track Track) error) func(context.Context, Track) error {
 	return func(ctx context.Context, track Track) error {
 		// first call
@@ -163,10 +167,12 @@ func WithRetry(opt RetryPolicy, fn func(ctx context.Context, track Track) error)
 			track.SetParentError(fmt.Errorf("retry [%d]", i))
 			select {
 			case <-ctx.Done():
+				err = ctx.Err()
 				track.SetStatus(ExecutionStatusFail)
 				track.AddError(
-					errors.Join(ErrRetryContextDone, ctx.Err()),
+					errors.Join(ErrRetryContextDone, err),
 				)
+
 				break stop
 			default:
 				err = fn(ctx, track)
@@ -183,6 +189,9 @@ func WithRetry(opt RetryPolicy, fn func(ctx context.Context, track Track) error)
 		}
 
 		track.SetParentError(nil)
+		if err != nil {
+			return ErrRetryFailed
+		}
 		return nil
 	}
 }

--- a/saga/saga.go
+++ b/saga/saga.go
@@ -42,15 +42,6 @@ var (
 	ErrRetryContextDone = fmt.Errorf("retry context done")
 )
 
-type Track interface {
-	call()
-	setParentError(error)
-
-	SetStatus(ExecutionStatus)
-	SetFailedOnError(error)
-	GetData() StepData
-}
-
 // Saga coordinates a distributed transaction using the `Saga` pattern.
 type Saga struct {
 	steps []Step
@@ -68,9 +59,8 @@ func NewSaga(steps []Step) *Saga {
 // If any step fails, compensating actions are triggered for all successfully completed steps.
 func (s *Saga) Execute(ctx context.Context) (Result, error) {
 	var (
-		tracks         []*inMemoryTrack
-		completedTrack []*inMemoryTrack
-		err            error
+		tracks         []*inMemoryTracker
+		completedTrack []*inMemoryTracker
 	)
 
 stop:
@@ -79,22 +69,25 @@ stop:
 			tr = newInMemoryTrack(
 				uint32(i),
 				step,
+				func(tracker Tracker) Track {
+					return NewExecutionTrack(tracker)
+				},
 			)
 		)
 
-		tr.actionTrack()
 		tracks = append(tracks, tr)
 		select {
 		case <-ctx.Done():
-			tr.SetFailedOnError(
-				fmt.Errorf("action failed [%d#%s]: %w", i, tr.StepName,
+			tr.action.SetStatus(ExecutionStatusFail)
+			tr.action.AddError(
+				fmt.Errorf("action failed [%d#%s]: %w", i, tr.stepName,
 					errors.Join(ctx.Err(), ErrExecuteActionsContextDone),
 				),
 			)
 			break stop
 		default:
 			if step.Action == nil {
-				tr.action.Status = ExecutionStatusUnset
+				tr.action.SetStatus(ExecutionStatusUnset)
 				continue
 			}
 
@@ -102,18 +95,20 @@ stop:
 				completedTrack = append(completedTrack, tr)
 			}
 
-			tr.call()
-			err = step.Action(ctx, tr)
+			tr.action.Call()
+			err := step.Action(ctx, tr.action)
 
-			switch status := tr.getStatus(); {
+			switch status := tr.action.GetTrackData().Status; {
 			case err == nil && status != ExecutionStatusFail:
-				tr.SetStatus(ExecutionStatusSuccess)
+				tr.action.SetStatus(ExecutionStatusSuccess)
 			case err != nil || status == ExecutionStatusFail:
 				if err != nil {
+					tr.action.SetStatus(ExecutionStatusFail)
 					err = errors.Join(err, ErrActionFailed)
-					tr.SetFailedOnError(
-						fmt.Errorf("action failed [%d#%s]: %w", i, tr.StepName, err),
+					tr.action.AddError(
+						fmt.Errorf("action failed [%d#%s]: %w", i, tr.stepName, err),
 					)
+
 				}
 				// Run compensation when error arise.
 				s.compensate(ctx, completedTrack)
@@ -131,34 +126,37 @@ stop:
 }
 
 // compensate triggers compensating actions for all steps in reverse order.
-func (s *Saga) compensate(ctx context.Context, tracks []*inMemoryTrack) {
+func (s *Saga) compensate(ctx context.Context, tracks []*inMemoryTracker) {
 stop:
 	for i, tr := range tracks {
-		if tr.compensationFn == nil {
+		if tr.compensationFunc == nil {
 			continue
 		}
-		tr.compensationTrack()
 		select {
 		case <-ctx.Done():
-			tr.SetFailedOnError(
-				fmt.Errorf("compensation failed [%d#%s]: %w", i, tr.StepName,
+			tr.compensation.SetStatus(ExecutionStatusFail)
+			tr.compensation.AddError(
+				fmt.Errorf("compensation failed [%d#%s]: %w", i, tr.stepName,
 					errors.Join(ctx.Err(), ErrExecuteCompensationContextDone),
 				),
 			)
+
 			break stop
 		default:
-			tr.call()
-			err := tr.compensationFn(ctx, tr)
+			tr.compensation.Call()
+			err := tr.compensationFunc(ctx, tr.compensation)
 			switch {
 			case err == nil:
+				comp := tr.compensation.GetTrackData()
 				// Determine final status based on error count vs calls
-				if uint32(len(tr.current.Errors)) == tr.current.Calls {
-					tr.SetStatus(ExecutionStatusFail)
+				if uint32(len(comp.Errors)) == comp.Calls {
+					tr.compensation.SetStatus(ExecutionStatusFail)
 				} else {
-					tr.SetStatus(ExecutionStatusSuccess)
+					tr.compensation.SetStatus(ExecutionStatusSuccess)
 				}
 			case err != nil:
-				tr.SetFailedOnError(fmt.Errorf("compensation failed [%d#%s]: %w", i, tr.StepName, err))
+				tr.compensation.SetStatus(ExecutionStatusFail)
+				tr.compensation.AddError(fmt.Errorf("compensation failed [%d#%s]: %w", i, tr.stepName, err))
 			}
 		}
 	}

--- a/saga/saga.go
+++ b/saga/saga.go
@@ -40,6 +40,12 @@ var (
 	// interrupted by context cancellation, meaning the operation was not completed
 	// and no more retries will be attempted.
 	ErrRetryContextDone = fmt.Errorf("retry context done")
+
+	// ErrRetryFailed indicates that all retry attempts have been exhausted without success.
+	// This error is returned when the maximum number of retry attempts configured in
+	// the RetryPolicy has been reached and every attempt failed. The original errors
+	// from each attempt are preserved in the Track's error list for debugging.
+	ErrRetryFailed = fmt.Errorf("retry failed")
 )
 
 // Saga coordinates a distributed transaction using the `Saga` pattern.
@@ -147,13 +153,7 @@ stop:
 			err := tr.compensationFunc(ctx, tr.compensation)
 			switch {
 			case err == nil:
-				comp := tr.compensation.GetTrackData()
-				// Determine final status based on error count vs calls
-				if uint32(len(comp.Errors)) == comp.Calls {
-					tr.compensation.SetStatus(ExecutionStatusFail)
-				} else {
-					tr.compensation.SetStatus(ExecutionStatusSuccess)
-				}
+				tr.compensation.SetStatus(ExecutionStatusSuccess)
 			case err != nil:
 				tr.compensation.SetStatus(ExecutionStatusFail)
 				tr.compensation.AddError(fmt.Errorf("compensation failed [%d#%s]: %w", i, tr.stepName, err))

--- a/saga/saga.go
+++ b/saga/saga.go
@@ -65,8 +65,8 @@ func NewSaga(steps []Step) *Saga {
 // If any step fails, compensating actions are triggered for all successfully completed steps.
 func (s *Saga) Execute(ctx context.Context) (Result, error) {
 	var (
-		tracks         []*inMemoryTracker
-		completedTrack []*inMemoryTracker
+		tracks         []*simpleTracker
+		completedTrack []*simpleTracker
 	)
 
 stop:
@@ -132,7 +132,7 @@ stop:
 }
 
 // compensate triggers compensating actions for all steps in reverse order.
-func (s *Saga) compensate(ctx context.Context, tracks []*inMemoryTracker) {
+func (s *Saga) compensate(ctx context.Context, tracks []*simpleTracker) {
 stop:
 	for i, tr := range tracks {
 		if tr.compensationFunc == nil {

--- a/saga/saga_test.go
+++ b/saga/saga_test.go
@@ -426,10 +426,11 @@ func Test_execute_context(t *testing.T) {
 		assert.Equal(t, 0, res.Steps[0].StepPosition)
 		assert.Equal(t, ExecutionStatusFail, res.Steps[0].Action.Status)
 		assert.Equal(t, ExecutionStatusUnset, res.Steps[0].Compensation.Status)
-		assert.Equal(t, 3, len(res.Steps[0].Action.Errors))
+		assert.Equal(t, 4, len(res.Steps[0].Action.Errors))
 		assert.ErrorIs(t, res.Steps[0].Action.Errors[0], testtool.ErrExpTestA)
 		assert.ErrorIs(t, res.Steps[0].Action.Errors[1], testtool.ErrExpTestA)
 		assert.ErrorIs(t, res.Steps[0].Action.Errors[2], ErrRetryContextDone)
+		assert.ErrorIs(t, res.Steps[0].Action.Errors[3], ErrRetryFailed)
 	})
 	//
 	t.Run("compensation_ctx_cancel", func(t *testing.T) {
@@ -541,9 +542,10 @@ func Test_hooks(t *testing.T) {
 			assert.Equal(t, 1, len(res.Steps))
 			assert.Equal(t, 2, res.Steps[0].Action.Calls)
 			assert.Equal(t, ExecutionStatusFail, res.Steps[0].Action.Status)
-			assert.Equal(t, 2, len(res.Steps[0].Action.Errors))
+			assert.Equal(t, 3, len(res.Steps[0].Action.Errors))
 			assert.ErrorIs(t, res.Steps[0].Action.Errors[0], testtool.ErrExpTestA)
 			assert.ErrorIs(t, res.Steps[0].Action.Errors[1], testtool.ErrExpTestA)
+			assert.ErrorIs(t, res.Steps[0].Action.Errors[2], ErrRetryFailed)
 			assert.True(t,
 				slices.Equal(
 					[]string{
@@ -712,9 +714,10 @@ func Test_hooks(t *testing.T) {
 
 								data := track.GetStepData()
 								assert.Equal(t, 3, data.Action.Calls)
-								assert.Equal(t, 9, len(data.Action.Errors))
+								assert.Equal(t, 10, len(data.Action.Errors))
 								assert.ErrorIs(t, data.Action.Errors[8], errHook2)
 								assert.True(t, checkRetryStr(1, data.Action.Errors[8]))
+								assert.ErrorIs(t, data.Action.Errors[9], ErrRetryFailed)
 								return errHook3
 							}).
 							WithAfterHook(func(ctx context.Context, track Track) error {
@@ -722,10 +725,11 @@ func Test_hooks(t *testing.T) {
 
 								data := track.GetStepData()
 								assert.Equal(t, 3, data.Action.Calls)
-								assert.Equal(t, 10, len(data.Action.Errors))
+								assert.Equal(t, 11, len(data.Action.Errors))
 								assert.ErrorIs(t, data.Action.Errors[8], errHook2)
 								assert.True(t, checkRetryStr(1, data.Action.Errors[8]))
-								assert.ErrorIs(t, data.Action.Errors[9], errHook3)
+								assert.ErrorIs(t, data.Action.Errors[9], ErrRetryFailed)
+								assert.ErrorIs(t, data.Action.Errors[10], errHook3)
 								return errHook4
 							}),
 					),
@@ -760,7 +764,7 @@ func Test_hooks(t *testing.T) {
 			action := res.Steps[0].Action
 			assert.Equal(t, 3, res.Steps[0].Action.Calls)
 			assert.Equal(t, ExecutionStatusFail, action.Status)
-			assert.Equal(t, 11, len(action.Errors))
+			assert.Equal(t, 12, len(action.Errors))
 			assert.ErrorIs(t, action.Errors[0], testtool.ErrExpTestA)
 			assert.ErrorIs(t, action.Errors[1], errHook1)
 			assert.ErrorIs(t, action.Errors[2], errHook2)
@@ -774,6 +778,12 @@ func Test_hooks(t *testing.T) {
 			assert.True(t, checkRetryStr(1, action.Errors[6]))
 			assert.ErrorIs(t, action.Errors[7], errHook1)
 			assert.True(t, checkRetryStr(1, action.Errors[7]))
+			assert.ErrorIs(t, action.Errors[8], errHook2)
+			assert.True(t, checkRetryStr(1, action.Errors[8]))
+			assert.ErrorIs(t, action.Errors[9], ErrRetryFailed)
+			assert.ErrorIs(t, action.Errors[10], errHook3)
+			assert.ErrorIs(t, action.Errors[11], errHook4)
+
 		})
 	})
 	t.Run("compensation_hooks", func(t *testing.T) {
@@ -1336,11 +1346,15 @@ func Test_retry(t *testing.T) {
 		assert.Equal(t, 0, res.Steps[0].StepPosition)
 		assert.Equal(t, ExecutionStatusFail, res.Steps[0].Action.Status)
 		assert.Equal(t, 5, res.Steps[0].Action.Calls)
-		assert.Equal(t, 5, len(res.Steps[0].Action.Errors))
+		assert.Equal(t, 6, len(res.Steps[0].Action.Errors))
 
-		for _, e := range res.Steps[0].Action.Errors {
+		// check all errors except on [ErrRetryFailed]
+		for i := 0; i < len(res.Steps[0].Action.Errors)-1; i++ {
+			e := res.Steps[0].Action.Errors[i]
 			assert.ErrorIs(t, e, testtool.ErrExpTestA)
 		}
+		// check last [ErrRetryFailed] error
+		assert.ErrorIs(t, res.Steps[0].Action.Errors[len(res.Steps[0].Action.Errors)-1], ErrRetryFailed)
 
 		assert.Equal(t, ExecutionStatusSuccess, res.Steps[0].Compensation.Status)
 		assert.Equal(t, 5, res.Steps[0].Compensation.Calls)
@@ -1388,18 +1402,27 @@ func Test_retry(t *testing.T) {
 		assert.Equal(t, 0, res.Steps[0].StepPosition)
 		assert.Equal(t, ExecutionStatusFail, res.Steps[0].Action.Status)
 		assert.Equal(t, 5, res.Steps[0].Action.Calls)
-		assert.Equal(t, 5, len(res.Steps[0].Action.Errors))
+		assert.Equal(t, 6, len(res.Steps[0].Action.Errors))
 
-		for _, e := range res.Steps[0].Action.Errors {
+		// check all errors except on [ErrRetryFailed]
+		for i := 0; i < len(res.Steps[0].Action.Errors)-1; i++ {
+			e := res.Steps[0].Action.Errors[i]
 			assert.ErrorIs(t, e, testtool.ErrExpTestA)
 		}
+		// check last [ErrRetryFailed] error
+		assert.ErrorIs(t, res.Steps[0].Action.Errors[len(res.Steps[0].Action.Errors)-1], ErrRetryFailed)
 
 		assert.Equal(t, ExecutionStatusFail, res.Steps[0].Compensation.Status)
 		assert.Equal(t, 5, res.Steps[0].Compensation.Calls)
-		assert.Equal(t, 5, len(res.Steps[0].Compensation.Errors))
-		for _, e := range res.Steps[0].Compensation.Errors {
+		assert.Equal(t, 6, len(res.Steps[0].Compensation.Errors))
+
+		// check all errors except on [ErrRetryFailed]
+		for i := 0; i < len(res.Steps[0].Compensation.Errors)-1; i++ {
+			e := res.Steps[0].Compensation.Errors[i]
 			assert.ErrorIs(t, e, testtool.ErrExpTestB)
 		}
+		// check last [ErrRetryFailed] error
+		assert.ErrorIs(t, res.Steps[0].Compensation.Errors[len(res.Steps[0].Compensation.Errors)-1], ErrRetryFailed)
 
 		testtool.TestFn(t, func() {
 			t.Log(

--- a/saga/saga_test.go
+++ b/saga/saga_test.go
@@ -265,7 +265,7 @@ func Test_Saga_panic_recovery(t *testing.T) {
 						return testtool.ErrExpTestA
 					}),
 					Compensation: CompensationFunc(func(ctx context.Context, track Track) error {
-						str := track.GetData()
+						str := track.GetStepData()
 						assert.Equal(t, 1, len(str.Action.Errors))
 						assert.Equal(t, 1, str.Action.Calls)
 						assert.Equal(t, ExecutionStatusFail, str.Action.Status)
@@ -341,7 +341,7 @@ func Test_execute_context(t *testing.T) {
 	t.Run("action_ctx_cancel", func(t *testing.T) {
 		var (
 			ctx, cancel = context.WithCancel(context.Background())
-			calls       = make([]string, 0, 2)
+			Calls       = make([]string, 0, 2)
 		)
 
 		steps := []Step{
@@ -349,18 +349,18 @@ func Test_execute_context(t *testing.T) {
 				WithAction(nil),
 			NewStep("step1").
 				WithAction(func(ctx context.Context, _ Track) error {
-					calls = append(calls, "action1")
+					Calls = append(Calls, "action1")
 					return nil
 				}),
 			NewStep("step2").
 				WithAction(func(ctx context.Context, _ Track) error {
-					calls = append(calls, "action2")
+					Calls = append(Calls, "action2")
 					cancel() // cancel context for test
 					return nil
 				}),
 			NewStep("step3").
 				WithAction(func(ctx context.Context, _ Track) error {
-					calls = append(calls, "action3")
+					Calls = append(Calls, "action3")
 					t.Fatalf("should not have been called")
 					return nil
 				}),
@@ -398,7 +398,7 @@ func Test_execute_context(t *testing.T) {
 		assert.Equal(t, 0, len(res.Steps[3].Compensation.Errors))
 		assert.Equal(t, false, res.Steps[3].CompensationRequired)
 
-		assert.True(t, slices.Equal([]string{"action1", "action2"}, calls))
+		assert.True(t, slices.Equal([]string{"action1", "action2"}, Calls))
 	})
 	t.Run("retry_ctx_cancel", func(t *testing.T) {
 		var (
@@ -409,7 +409,7 @@ func Test_execute_context(t *testing.T) {
 			NewStep("step0").
 				WithAction(
 					NewAction(func(ctx context.Context, track Track) error {
-						data := track.GetData()
+						data := track.GetStepData()
 						if data.Action.Calls >= 2 {
 							cancel() // cancel context for test
 						}
@@ -577,7 +577,7 @@ func Test_hooks(t *testing.T) {
 						}).WithAfterHook(func(ctx context.Context, track Track) error {
 							executed = append(executed, "hook1")
 
-							data := track.GetData()
+							data := track.GetStepData()
 							assert.Equal(t, 1, data.Action.Calls)
 							assert.Equal(t, 1, len(data.Action.Errors))
 							assert.ErrorIs(t, data.Action.Errors[0], testtool.ErrExpTestA)
@@ -587,7 +587,7 @@ func Test_hooks(t *testing.T) {
 						}).WithAfterHook(func(ctx context.Context, track Track) error {
 							executed = append(executed, "hook2")
 
-							data := track.GetData()
+							data := track.GetStepData()
 							assert.Equal(t, 1, data.Action.Calls)
 							assert.Equal(t, 2, len(data.Action.Errors))
 							assert.ErrorIs(t, data.Action.Errors[0], testtool.ErrExpTestA)
@@ -626,7 +626,7 @@ func Test_hooks(t *testing.T) {
 						NewAction(func(ctx context.Context, track Track) error {
 							executed = append(executed, "action1")
 
-							data := track.GetData()
+							data := track.GetStepData()
 							switch data.Action.Calls {
 							case 1:
 								return testtool.ErrExpTestA
@@ -641,7 +641,7 @@ func Test_hooks(t *testing.T) {
 						}).WithAfterHook(func(ctx context.Context, track Track) error {
 							executed = append(executed, "hook1")
 
-							data := track.GetData()
+							data := track.GetStepData()
 							switch data.Action.Calls {
 							case 1:
 								assert.Equal(t, 1, len(data.Action.Errors))
@@ -673,7 +673,7 @@ func Test_hooks(t *testing.T) {
 						}).WithAfterHook(func(ctx context.Context, track Track) error {
 							executed = append(executed, "hook2")
 
-							data := track.GetData()
+							data := track.GetStepData()
 							switch data.Action.Calls {
 							case 1:
 								assert.Equal(t, 2, len(data.Action.Errors))
@@ -710,7 +710,7 @@ func Test_hooks(t *testing.T) {
 							WithAfterHook(func(ctx context.Context, track Track) error {
 								executed = append(executed, "retry_hook1")
 
-								data := track.GetData()
+								data := track.GetStepData()
 								assert.Equal(t, 3, data.Action.Calls)
 								assert.Equal(t, 9, len(data.Action.Errors))
 								assert.ErrorIs(t, data.Action.Errors[8], errHook2)
@@ -720,7 +720,7 @@ func Test_hooks(t *testing.T) {
 							WithAfterHook(func(ctx context.Context, track Track) error {
 								executed = append(executed, "retry_hook2")
 
-								data := track.GetData()
+								data := track.GetStepData()
 								assert.Equal(t, 3, data.Action.Calls)
 								assert.Equal(t, 10, len(data.Action.Errors))
 								assert.ErrorIs(t, data.Action.Errors[8], errHook2)
@@ -794,7 +794,7 @@ func Test_hooks(t *testing.T) {
 					NewCompensation(func(ctx context.Context, track Track) error {
 						executed = append(executed, "comp1")
 
-						data := track.GetData()
+						data := track.GetStepData()
 						assert.Equal(t, 1, data.Action.Calls)
 						assert.Equal(t, 1, data.Compensation.Calls)
 						assert.Equal(t, 1, len(data.Action.Errors))
@@ -804,7 +804,7 @@ func Test_hooks(t *testing.T) {
 					}).WithBeforeHook(func(ctx context.Context, track Track) error {
 						executed = append(executed, "comp_hook1")
 
-						data := track.GetData()
+						data := track.GetStepData()
 						assert.Equal(t, 1, data.Action.Calls)
 						assert.Equal(t, 1, data.Compensation.Calls)
 						assert.Equal(t, 1, len(data.Action.Errors))
@@ -813,7 +813,7 @@ func Test_hooks(t *testing.T) {
 					}).WithBeforeHook(func(ctx context.Context, track Track) error {
 						executed = append(executed, "comp_hook2")
 
-						data := track.GetData()
+						data := track.GetStepData()
 						assert.Equal(t, 1, data.Action.Calls)
 						assert.Equal(t, 1, data.Compensation.Calls)
 						assert.Equal(t, 1, len(data.Action.Errors))
@@ -864,7 +864,7 @@ func Test_hooks(t *testing.T) {
 					}).WithAfterHook(func(ctx context.Context, track Track) error {
 						executed = append(executed, "comp_hook1")
 
-						data := track.GetData()
+						data := track.GetStepData()
 						assert.Equal(t, 1, data.Action.Calls)
 						assert.Equal(t, 1, data.Compensation.Calls)
 						assert.Equal(t, 1, len(data.Action.Errors))
@@ -876,7 +876,7 @@ func Test_hooks(t *testing.T) {
 					}).WithAfterHook(func(ctx context.Context, track Track) error {
 						executed = append(executed, "comp_hook2")
 
-						data := track.GetData()
+						data := track.GetStepData()
 						assert.Equal(t, 1, data.Action.Calls)
 						assert.Equal(t, 1, data.Compensation.Calls)
 						assert.Equal(t, 1, len(data.Action.Errors))
@@ -906,20 +906,20 @@ func Test_wrapper(t *testing.T) {
 	)
 	t.Run("action", func(t *testing.T) {
 		var (
-			calls = make([]string, 0, 3)
+			Calls = make([]string, 0, 3)
 		)
 
 		steps := []Step{
 			NewStep("step1").
 				WithAction(
 					NewAction(func(ctx context.Context, _ Track) error {
-						calls = append(calls, "action1")
+						Calls = append(Calls, "action1")
 						return nil
 					}).WithWrapper(func(ctx context.Context, track Track, action ActionFunc) error {
-						calls = append(calls, "before1")
+						Calls = append(Calls, "before1")
 						err := action(ctx, track)
 						assert.NoError(t, err)
-						calls = append(calls, "after1")
+						Calls = append(Calls, "after1")
 						return nil
 					}),
 				),
@@ -934,43 +934,43 @@ func Test_wrapper(t *testing.T) {
 		assert.Equal(t, 0, res.Steps[0].Compensation.Calls)
 		assert.Equal(t, ExecutionStatusUnset, res.Steps[0].Compensation.Status)
 
-		assert.True(t, slices.Equal([]string{"before1", "action1", "after1"}, calls))
+		assert.True(t, slices.Equal([]string{"before1", "action1", "after1"}, Calls))
 	})
 	t.Run("compensation", func(t *testing.T) {
 		var (
 			expErr = testtool.ErrExpTestA
-			calls  = make([]string, 0, 6)
+			Calls  = make([]string, 0, 6)
 		)
 
 		steps := []Step{
 			NewStep("step1").
 				WithAction(
 					NewAction(func(ctx context.Context, _ Track) error {
-						calls = append(calls, "action1")
+						Calls = append(Calls, "action1")
 						return expErr
 					}).WithWrapper(func(ctx context.Context, track Track, action ActionFunc) error {
-						calls = append(calls, "before_action1")
+						Calls = append(Calls, "before_action1")
 						err := action(ctx, track) // call action
 						assert.Error(t, err)
 						assert.ErrorIs(t, err, expErr)
-						calls = append(calls, "after_action1")
+						Calls = append(Calls, "after_action1")
 						return err
 					}),
 				).WithCompensation(
 				NewCompensation(func(ctx context.Context, track Track) error {
-					calls = append(calls, "com1")
-					actionErr := track.GetData().Action.Errors[0]
+					Calls = append(Calls, "com1")
+					actionErr := track.GetStepData().Action.Errors[0]
 					assert.Error(t, actionErr)
 					assert.ErrorIs(t, actionErr, expErr)
 					return nil
 				}).WithWrapper(func(ctx context.Context, track Track, comp CompensationFunc) error {
-					calls = append(calls, "before_comp1")
-					actionErr := track.GetData().Action.Errors[0]
+					Calls = append(Calls, "before_comp1")
+					actionErr := track.GetStepData().Action.Errors[0]
 					assert.Error(t, actionErr)
 					assert.ErrorIs(t, actionErr, expErr)
 					err := comp(ctx, track) // call compensation
 					assert.NoError(t, err)
-					calls = append(calls, "after_comp1")
+					Calls = append(Calls, "after_comp1")
 					return nil
 				}),
 			).WithCompensationRequired(),
@@ -991,7 +991,7 @@ func Test_wrapper(t *testing.T) {
 				[]string{
 					"before_action1", "action1", "after_action1",
 					"before_comp1", "com1", "after_comp1",
-				}, calls))
+				}, Calls))
 	})
 }
 
@@ -1113,7 +1113,7 @@ func Test_steps(t *testing.T) {
 					).
 					WithCompensation(
 						NewCompensation(func(ctx context.Context, track Track) error {
-							str := track.GetData()
+							str := track.GetStepData()
 							assert.Equal(t, "step1", str.StepName)
 							assert.Equal(t, 0, str.StepPosition)
 							assert.Equal(t, ExecutionStatusFail, str.Action.Status)
@@ -1159,7 +1159,7 @@ func Test_steps(t *testing.T) {
 					).
 					WithCompensation(
 						NewCompensation(func(ctx context.Context, track Track) error {
-							str := track.GetData()
+							str := track.GetStepData()
 							assert.Equal(t, "step1", str.StepName)
 							assert.Equal(t, 0, str.StepPosition)
 							assert.Equal(t, ExecutionStatusFail, str.Action.Status)
@@ -1255,7 +1255,7 @@ func Test_steps(t *testing.T) {
 					).
 					WithCompensation(
 						NewCompensation(func(ctx context.Context, track Track) error {
-							str := track.GetData()
+							str := track.GetStepData()
 							assert.Equal(t, "step1", str.StepName)
 							assert.Equal(t, 0, str.StepPosition)
 							assert.Equal(t, ExecutionStatusFail, str.Action.Status)
@@ -1315,7 +1315,7 @@ func Test_retry(t *testing.T) {
 				).
 				WithCompensation(
 					NewCompensation(func(ctx context.Context, track Track) error {
-						str := track.GetData()
+						str := track.GetStepData()
 						if str.Compensation.Calls < retries+1 {
 							return fmt.Errorf("comp err [%d]: %w", len(str.Compensation.Errors), testtool.ErrExpTestA)
 						}
@@ -1370,7 +1370,7 @@ func Test_retry(t *testing.T) {
 				).
 				WithCompensation(
 					NewCompensation(func(ctx context.Context, track Track) error {
-						str := track.GetData()
+						str := track.GetStepData()
 						return fmt.Errorf("comp err [%d]: %w", len(str.Compensation.Errors), testtool.ErrExpTestB)
 					}).WithRetry(NewBaseRetryOpt(4, 5*time.Nanosecond)),
 				).WithCompensationRequired(),

--- a/saga/track.go
+++ b/saga/track.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"sync"
 )
 
 // ExecutionStatus represents the current state of an action or compensation execution.
@@ -21,14 +20,36 @@ const (
 	ExecutionStatusUnset ExecutionStatus = "Unset"
 )
 
+type (
+	// Tracker provides access to step data for a specific saga step.
+	Tracker interface {
+		GetStepData() StepData
+	}
+
+	// Track represents an executable operation within a saga step.
+	Track interface {
+		Call()
+		SetStatus(ExecutionStatus)
+		SetParentError(error)
+		AddError(error)
+
+		GetStepData() StepData
+		GetTrackData() TrackData
+	}
+)
+
 // StepData contains the complete execution history for a single saga step.
-// It includes information about both the main action and its compensation.
 type StepData struct {
+	// StepPosition is the index of this step in the saga.
 	StepPosition uint32
 	StepName     string
 
-	Action               ExecutionData
-	Compensation         ExecutionData
+	// Action is the execution data for the main action.
+	Action TrackData
+	// Compensation is the xecution data for the compensation operation.
+	Compensation TrackData
+
+	// CompensationRequired define when compensation should be triggered on failure.
 	CompensationRequired bool
 }
 
@@ -38,158 +59,154 @@ func (s StepData) String() string {
 		s.StepPosition,
 		s.StepName,
 		s.Action.String(),
-		s.Compensation.String())
+		s.Compensation.String(),
+	)
 }
 
-// ExecutionData holds execution details for a single operation (action or compensation).
-type ExecutionData struct {
+// TrackData contains immutable execution metrics for a single operation.
+type TrackData struct {
 	Calls  uint32
 	Errors []error
 	Status ExecutionStatus
 }
 
-// String returns a compact representation of ExecutionData.
-func (ed ExecutionData) String() string {
+// String returns a compact representation of TrackData.
+func (ed *TrackData) String() string {
 	var builder strings.Builder
+	switch {
+	case ed == nil:
+		builder.WriteString(fmt.Sprintf("{Status: %s, Calls: %d", "nil", -1))
+	default:
+		builder.WriteString(fmt.Sprintf("{Status: %s, Calls: %d", ed.Status, ed.Calls))
+		if len(ed.Errors) > 0 {
+			builder.WriteString(fmt.Sprintf(", Errors: %d", len(ed.Errors)))
+			// @TODO: add errors output
+			//if len(ed.Errors) == 1 {
+			//	builder.WriteString(fmt.Sprintf(" [%v]", ed.Errors[0]))
+			//}
+		}
 
-	builder.WriteString(fmt.Sprintf("{Status: %s, Calls: %d", ed.Status, ed.Calls))
-	if len(ed.Errors) > 0 {
-		builder.WriteString(fmt.Sprintf(", Errors: %d", len(ed.Errors)))
-		// @TODO: add errors output
-		//if len(ed.Errors) == 1 {
-		//	builder.WriteString(fmt.Sprintf(" [%v]", ed.Errors[0]))
-		//}
 	}
 
 	builder.WriteString("}")
 	return builder.String()
 }
 
-// Clone creates a deep copy of ExecutionData.
-func (ed ExecutionData) Clone() ExecutionData {
-	return ExecutionData{
-		Calls:  ed.Calls,
-		Errors: slices.Clone(ed.Errors),
-		Status: ed.Status,
+// ExecutionTrack holds execution details for a single operation.
+type ExecutionTrack struct {
+	calls       uint32
+	parentError error
+	errors      []error
+	status      ExecutionStatus
+
+	tracker Tracker
+}
+
+// NewExecutionTrack creates a new ExecutionTrack.
+func NewExecutionTrack(tracker Tracker) *ExecutionTrack {
+	return &ExecutionTrack{
+		status:  ExecutionStatusUncalled,
+		tracker: tracker,
 	}
 }
 
-// inMemoryTrack manages the execution state for a single saga step.
-// It implements the Track interface and provides thread-safe state management.
-type inMemoryTrack struct {
-	StepName     string
-	StepPosition uint32
+// Calls returns the number of times this operation has been invoked.
+func (ed *ExecutionTrack) Calls() uint32 {
+	return ed.calls
+}
 
-	mx *sync.RWMutex
+// Errors returns the list of errors that occurred during execution.
+func (ed *ExecutionTrack) Errors() []error {
+	return ed.errors
+}
 
-	action       *ExecutionData
-	compensation *ExecutionData
-	current      *ExecutionData
+// Call increments the call counter for this execution track.
+func (ed *ExecutionTrack) Call() {
+	ed.calls++
+}
 
-	CompensationRequired bool
-	compensationFn       CompensationFunc
+// SetStatus updates the execution status of this track.
+func (ed *ExecutionTrack) SetStatus(status ExecutionStatus) {
+	ed.status = status
+}
+
+// SetParentError sets a parent error that will be wrapped with any subsequent errors added.
+func (ed *ExecutionTrack) SetParentError(err error) {
+	ed.parentError = err
+}
+
+// AddError appends an error to the track's error list.
+// If a parent error is set, it will be wrapped with the new error.
+// Nil errors are silently ignored.
+func (ed *ExecutionTrack) AddError(err error) {
+	if err == nil || ed == nil {
+		return
+	}
+	if ed.parentError != nil {
+		err = fmt.Errorf("%w: %w", ed.parentError, err)
+	}
+	ed.errors = append(ed.errors, err)
+}
+
+// GetStepData returns the StepData from the associated tracker.
+func (ed *ExecutionTrack) GetStepData() StepData {
+	return ed.tracker.GetStepData()
+}
+
+// GetTrackData creates a deep copy of TrackData.
+func (ed *ExecutionTrack) GetTrackData() TrackData {
+	return TrackData{
+		Calls:  ed.calls,
+		Errors: slices.Clone(ed.errors),
+		Status: ed.status,
+	}
+}
+
+// inMemoryTracker manages the execution state for a single saga step.
+type inMemoryTracker struct {
+	stepName     string
+	stepPosition uint32
+
+	action       Track
+	compensation Track
+
+	compensationRequired bool
 	parentErr            error
+
+	compensationFunc CompensationFunc
 }
 
-// newInMemoryTrack creates a new inMemoryTrack for a given step.
-func newInMemoryTrack(position uint32, step Step) *inMemoryTrack {
-	track := inMemoryTrack{
-		StepName:     step.Name,
-		StepPosition: position,
-		mx:           new(sync.RWMutex),
-		action: &ExecutionData{
-			Status: ExecutionStatusUncalled,
-		},
-		compensation: &ExecutionData{
-			Status: ExecutionStatusUncalled,
-		},
-		CompensationRequired: step.CompensationRequired,
-		compensationFn:       step.Compensation,
+// newInMemoryTrack creates a new inMemoryTracker for a given step.
+func newInMemoryTrack(position uint32, step Step, trackFactory func(Tracker) Track) *inMemoryTracker {
+
+	tracker := &inMemoryTracker{
+		stepName:             step.Name,
+		stepPosition:         position,
+		compensationRequired: step.CompensationRequired,
+		compensationFunc:     step.Compensation,
 	}
+
+	tracker.action = trackFactory(tracker)
+	tracker.compensation = trackFactory(tracker)
 
 	if step.Compensation == nil {
-		track.compensation.Status = ExecutionStatusUnset
+		tracker.compensation.SetStatus(ExecutionStatusUnset)
 	}
 
 	if step.Action == nil {
-		track.action.Status = ExecutionStatusUnset
+		tracker.action.SetStatus(ExecutionStatusUnset)
 	}
 
-	return &track
+	return tracker
 }
 
-// actionTrack switches the current execution context to the action.
-// Returns the track for method chaining.
-func (t *inMemoryTrack) actionTrack() *inMemoryTrack {
-	t.mx.Lock()
-	defer t.mx.Unlock()
-	t.current = t.action
-	return t
-}
-
-// compensationTrack switches the current execution context to the compensation.
-// Returns the track for method chaining.
-func (t *inMemoryTrack) compensationTrack() *inMemoryTrack {
-	t.mx.Lock()
-	defer t.mx.Unlock()
-	t.current = t.compensation
-	return t
-}
-
-// call increments the call counter for the current execution context.
-// Should be called before each invocation of the operation.
-func (t *inMemoryTrack) call() {
-	t.mx.Lock()
-	defer t.mx.Unlock()
-	t.current.Calls = t.current.Calls + 1
-}
-
-// setParentError sets a parent error that will be wrapped with subsequent errors.
-// Used to provide context about which retry attempt or operation triggered an error.
-func (t *inMemoryTrack) setParentError(err error) {
-	t.mx.Lock()
-	defer t.mx.Unlock()
-	t.parentErr = err
-}
-
-// SetStatus sets the status of the current execution context.
-func (t *inMemoryTrack) SetStatus(status ExecutionStatus) {
-	t.mx.Lock()
-	defer t.mx.Unlock()
-	t.current.Status = status
-}
-
-// getStatus returns the status of the current execution context.
-func (t *inMemoryTrack) getStatus() ExecutionStatus {
-	t.mx.RLock()
-	defer t.mx.RUnlock()
-	return t.current.Status
-}
-
-// SetFailedOnError marks the current execution as failed and records the error.
-// If a parent error exists, it will be wrapped with the new error.
-func (t *inMemoryTrack) SetFailedOnError(err error) {
-	t.mx.Lock()
-	defer t.mx.Unlock()
-	if err == nil {
-		return
-	}
-	if t.parentErr != nil {
-		err = fmt.Errorf("%w: %w", t.parentErr, err)
-	}
-	t.current.Status = ExecutionStatusFail
-	t.current.Errors = append(t.current.Errors, err)
-}
-
-// GetData returns a snapshot of the current execution state for this step.
-func (t *inMemoryTrack) GetData() StepData {
-	t.mx.RLock()
-	defer t.mx.RUnlock()
+// GetStepData returns a snapshot of the current step state.
+func (t *inMemoryTracker) GetStepData() StepData {
 	return StepData{
-		StepName:             t.StepName,
-		StepPosition:         t.StepPosition,
-		Action:               t.action.Clone(),
-		Compensation:         t.compensation.Clone(),
-		CompensationRequired: t.CompensationRequired,
+		StepName:             t.stepName,
+		StepPosition:         t.stepPosition,
+		Action:               t.action.GetTrackData(),
+		Compensation:         t.compensation.GetTrackData(),
+		CompensationRequired: t.compensationRequired,
 	}
 }

--- a/saga/track.go
+++ b/saga/track.go
@@ -162,28 +162,26 @@ func (ed *ExecutionTrack) GetTrackData() TrackData {
 	}
 }
 
-// inMemoryTracker manages the execution state for a single saga step.
-type inMemoryTracker struct {
+// simpleTracker manages the execution state for a single saga step.
+type simpleTracker struct {
 	stepName     string
 	stepPosition uint32
 
 	action       Track
 	compensation Track
 
+	compensationFunc     CompensationFunc
 	compensationRequired bool
-	parentErr            error
-
-	compensationFunc CompensationFunc
 }
 
-// newInMemoryTrack creates a new inMemoryTracker for a given step.
-func newInMemoryTrack(position uint32, step Step, trackFactory func(Tracker) Track) *inMemoryTracker {
+// newInMemoryTrack creates a new simpleTracker for a given step.
+func newInMemoryTrack(position uint32, step Step, trackFactory func(Tracker) Track) *simpleTracker {
 
-	tracker := &inMemoryTracker{
+	tracker := &simpleTracker{
 		stepName:             step.Name,
 		stepPosition:         position,
-		compensationRequired: step.CompensationRequired,
 		compensationFunc:     step.Compensation,
+		compensationRequired: step.CompensationRequired,
 	}
 
 	tracker.action = trackFactory(tracker)
@@ -201,7 +199,7 @@ func newInMemoryTrack(position uint32, step Step, trackFactory func(Tracker) Tra
 }
 
 // GetStepData returns a snapshot of the current step state.
-func (t *inMemoryTracker) GetStepData() StepData {
+func (t *simpleTracker) GetStepData() StepData {
 	return StepData{
 		StepName:             t.stepName,
 		StepPosition:         t.stepPosition,

--- a/test/bench/clone_test.go
+++ b/test/bench/clone_test.go
@@ -13,54 +13,54 @@ import (
 func Benchmark_copy(b *testing.B) {
 	const (
 		letters   = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-		errorsLen = 100
+		ErrorsLen = 100
 	)
 	var (
 		generator = rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), uint64(time.Now().UnixNano())))
-		genFn     = func() saga.ExecutionData {
+		genFn     = func() saga.TrackData {
 			b.Helper()
-			errors := make([]error, errorsLen)
-			for i := 0; i < errorsLen; i++ {
+			Errors := make([]error, ErrorsLen)
+			for i := 0; i < ErrorsLen; i++ {
 				b := make([]byte, 10)
 				for i := range b {
 					b[i] = letters[generator.IntN(len(letters))]
 				}
-				errors[i] = fmt.Errorf("%s", string(b))
+				Errors[i] = fmt.Errorf("%s", string(b))
 			}
 
-			return saga.ExecutionData{
+			return saga.TrackData{
 				Calls:  generator.Uint32(),
-				Errors: errors,
+				Errors: Errors,
 				Status: saga.ExecutionStatusSuccess,
 			}
 		}
 
-		slicesClone = func(in saga.ExecutionData) saga.ExecutionData {
+		slicesClone = func(in saga.TrackData) saga.TrackData {
 			b.Helper()
-			return saga.ExecutionData{
+			return saga.TrackData{
 				Calls:  in.Calls,
 				Errors: slices.Clone(in.Errors),
 				Status: in.Status,
 			}
 		}
 
-		oldCopy = func(in saga.ExecutionData) saga.ExecutionData {
+		oldCopy = func(in saga.TrackData) saga.TrackData {
 			b.Helper()
-			errors := make([]error, len(in.Errors))
-			copy(errors, in.Errors)
-			return saga.ExecutionData{
+			Errors := make([]error, len(in.Errors))
+			copy(Errors, in.Errors)
+			return saga.TrackData{
 				Calls:  in.Calls,
-				Errors: errors,
+				Errors: Errors,
 				Status: in.Status,
 			}
 		}
 	)
 
-	b.Run(fmt.Sprintf("size_%d", errorsLen), func(b *testing.B) {
+	b.Run(fmt.Sprintf("size_%d", ErrorsLen), func(b *testing.B) {
 		b.Run("copy", func(b *testing.B) {
 			var (
 				in  = genFn()
-				res saga.ExecutionData
+				res saga.TrackData
 			)
 
 			b.ResetTimer()
@@ -75,7 +75,7 @@ func Benchmark_copy(b *testing.B) {
 		b.Run("slices.Clone", func(b *testing.B) {
 			var (
 				in  = genFn()
-				res saga.ExecutionData
+				res saga.TrackData
 			)
 
 			b.ResetTimer()
@@ -92,7 +92,7 @@ func Benchmark_copy(b *testing.B) {
 		b.Run("copy", func(b *testing.B) {
 			var (
 				in  = genFn()
-				res saga.ExecutionData
+				res saga.TrackData
 			)
 
 			b.ResetTimer()
@@ -108,7 +108,7 @@ func Benchmark_copy(b *testing.B) {
 		b.Run("slices.Clone", func(b *testing.B) {
 			var (
 				in  = genFn()
-				res saga.ExecutionData
+				res saga.TrackData
 			)
 
 			b.ResetTimer()
@@ -122,12 +122,12 @@ func Benchmark_copy(b *testing.B) {
 		})
 	})
 
-	b.Run(fmt.Sprintf("empty_with_cap_%d", errorsLen), func(b *testing.B) {
+	b.Run(fmt.Sprintf("empty_with_cap_%d", ErrorsLen), func(b *testing.B) {
 		b.Run("copy", func(b *testing.B) {
 
 			var (
 				in  = genFn()
-				res saga.ExecutionData
+				res saga.TrackData
 			)
 			res.Errors = nil
 
@@ -144,7 +144,7 @@ func Benchmark_copy(b *testing.B) {
 		b.Run("slices.Clone", func(b *testing.B) {
 			var (
 				in  = genFn()
-				res saga.ExecutionData
+				res saga.TrackData
 			)
 			b.ResetTimer()
 			b.ReportAllocs()

--- a/test/integration/internal/saga/facade_multi_test.go
+++ b/test/integration/internal/saga/facade_multi_test.go
@@ -144,7 +144,7 @@ func Test_Saga_multi_Facade(t *testing.T) {
 					return err
 				},
 				Compensation: func(ctx context.Context, track saga.Track) error {
-					data := track.GetData()
+					data := track.GetStepData()
 					assert.Len(t, data.Action.Errors, 0)
 
 					err := sqlTransactor.WithinTx(ctx, func(ctx context.Context) error {
@@ -164,7 +164,7 @@ func Test_Saga_multi_Facade(t *testing.T) {
 					return err
 				},
 				Compensation: func(ctx context.Context, track saga.Track) error {
-					data := track.GetData()
+					data := track.GetStepData()
 					assert.Len(t, data.Action.Errors, 0)
 
 					t.Log(data)
@@ -273,7 +273,7 @@ func Test_Saga_multi_Facade(t *testing.T) {
 					// Compensation logic.
 					//
 					// Check an error type and call compensation only for Mongo.
-					trackData := track.GetData()
+					trackData := track.GetStepData()
 					if len(trackData.Action.Errors) > 0 && errors.Is(trackData.Action.Errors[0], entity.ErrExpected) {
 						err = mongoRepo.Delete(ctx, mongoTestDataValA)
 						assert.NoError(t, err)


### PR DESCRIPTION
### Description
 1 - interfaces was added
``` go
type (
	// Tracker provides access to step data for a specific saga step.
	Tracker interface {
		GetStepData() StepData
	}

	// Track represents an executable operation within a saga step.
	Track interface { /// ⚠️⚠️⚠️
		Call()
		SetStatus(ExecutionStatus)
		SetParentError(error)
		AddError(error)

		GetStepData() StepData
		GetTrackData() TrackData
	}
)
```
2 - `retry` behavior was fixed
3 -  examples and Readme.md were fixed

Closes #212 