### PR TITLE
[#231] prevent overflow in exponential retry backoff

### DIFF
--- a/saga/backoff.go
+++ b/saga/backoff.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+const maxDuration = math.MaxInt64
+
 // ExponentialBackoff provides exponential backoff strategy without jitter.
 type ExponentialBackoff struct{}
 
@@ -14,7 +16,20 @@ func NewExponentialBackoff() ExponentialBackoff {
 }
 
 // Backoff calculates exponential backoff delay.
-func (o ExponentialBackoff) Backoff(attempt uint32, delay time.Duration) time.Duration {
-	backoffTime := delay * time.Duration(math.Pow(2, float64(attempt)))
-	return backoffTime
+//
+// The result saturates at the largest representable [time.Duration] instead of
+// overflowing into a negative duration.
+func (ExponentialBackoff) Backoff(attempt uint32, delay time.Duration) time.Duration {
+	if delay <= 0 {
+		return delay
+	}
+
+	for range attempt {
+		if delay > maxDuration/2 {
+			return maxDuration
+		}
+		delay *= 2
+	}
+
+	return delay
 }

--- a/saga/retry_test.go
+++ b/saga/retry_test.go
@@ -12,20 +12,42 @@ import (
 )
 
 func Test_backoff(t *testing.T) {
-	t.Run("exponential_v1", func(t *testing.T) {
-		var (
-			baseTime = time.Second
-		)
-		backoff := NewExponentialBackoff()
-		delay := backoff.Backoff(1, baseTime)
-		if delay <= baseTime {
-			t.Fail()
-		}
-	})
-	t.Run("nil_backoff_uses_exponential_default", func(t *testing.T) {
-		policy := NewAdvanceRetryPolicy(1, time.Second, nil)
+	t.Run("exponential", func(t *testing.T) {
+		t.Run("v1", func(t *testing.T) {
+			var (
+				baseTime = time.Second
+			)
+			backoff := NewExponentialBackoff()
+			delay := backoff.Backoff(1, baseTime)
+			if delay <= baseTime {
+				t.Fail()
+			}
+		})
 
-		assert.Equal(t, 2*time.Second, policy.Delay(1))
+		t.Run("v2", func(t *testing.T) {
+			backoff := NewExponentialBackoff()
+
+			assert.Equal(t, 8*time.Second, backoff.Backoff(3, time.Second))
+		})
+
+		t.Run("nil_backoff_uses_exponential_default", func(t *testing.T) {
+			policy := NewAdvanceRetryPolicy(1, time.Second, nil)
+
+			assert.Equal(t, 2*time.Second, policy.Delay(1))
+		})
+
+		t.Run("on_overflow", func(t *testing.T) {
+			backoff := NewExponentialBackoff()
+
+			assert.Equal(t, maxDuration, backoff.Backoff(64, time.Second))
+		})
+
+		t.Run("max_delay_applies_after_backoff_saturates", func(t *testing.T) {
+			policy := NewAdvanceRetryPolicy(64, time.Second, NewExponentialBackoff()).
+				WithMaxDelay(10 * time.Second)
+
+			assert.Equal(t, 10*time.Second, policy.Delay(64))
+		})
 	})
 }
 


### PR DESCRIPTION
### Description

Fixed!
The exponential delay must saturate at the maximum representable time.
Duration and never overflow into a zero or negative duration.

WithMaxDelay must still cap the saturated value to the configured maximum delay.

Closes #231 